### PR TITLE
Feature/sort non header tables

### DIFF
--- a/table-sort.js
+++ b/table-sort.js
@@ -32,8 +32,13 @@ for (j = 0; j < tableHeaders.length; ++j) {
 
     chrome.storage.local.get('sortEnabled', function (result) {
       if (result.sortEnabled) {
+        let appendingBody = tableObj;
+        let tbody = [...tableObj.querySelectorAll("TBODY")];
+        if (tbody.length) {
+          appendingBody = tbody[0];
+        }
         for (i = 0; i < nodeArray.length; ++i) {
-          tableObj.appendChild(nodeArray[i]);
+          appendingBody.appendChild(nodeArray[i]);
         }
       }
     });
@@ -41,14 +46,14 @@ for (j = 0; j < tableHeaders.length; ++j) {
 }
 
 function stableSort(arr, compare) {
-    var original = arr.slice(0);
+  var original = arr.slice(0);
 
-    arr.sort(function(a, b){
-        var result = compare(a, b);
-        return result === 0 ? original.indexOf(a) - original.indexOf(b) : result;
-    });
+  arr.sort(function(a, b){
+    var result = compare(a, b);
+    return result === 0 ? original.indexOf(a) - original.indexOf(b) : result;
+  });
 
-    return arr;
+  return arr;
 }
 
 function findParentNode(parentName, childObj) {
@@ -62,19 +67,19 @@ function findParentNode(parentName, childObj) {
 var reA = /[^a-zA-Z]/g;
 var reN = /[^-.0-9]/g;
 function sortAlphaNum(a,b) {
-    var aA = a.replace(reA, "");
-    var bA = b.replace(reA, "");
-    if(aA === bA) {
-        var aN = parseFloat(a.replace(reN, ""));
-        var bN = parseFloat(b.replace(reN, ""));
-        if (isNaN(aN)){
-          aN = 0;
-        }
-        if (isNaN(bN)){
-          bN = 0;
-        }
-        return aN === bN ? 0 : aN > bN ? 1 : -1;
-    } else {
-        return aA > bA ? 1 : -1;
+  var aA = a.replace(reA, "");
+  var bA = b.replace(reA, "");
+  if(aA === bA) {
+    var aN = parseFloat(a.replace(reN, ""));
+    var bN = parseFloat(b.replace(reN, ""));
+    if (isNaN(aN)){
+      aN = 0;
     }
+    if (isNaN(bN)){
+      bN = 0;
+    }
+    return aN === bN ? 0 : aN > bN ? 1 : -1;
+  } else {
+    return aA > bA ? 1 : -1;
+  }
 }

--- a/table-sort.js
+++ b/table-sort.js
@@ -1,9 +1,14 @@
-var tableHeaders = document.querySelectorAll('th');
-var sortAsc = Array(tableHeaders.length);
-sortAsc.fill(1);
-
+const tableHeaders = Array.from(document.querySelectorAll('TABLE'), table => {
+  let THs = table.querySelectorAll("TH");
+  if (THs.length) return [...THs]
+  let TRs = table.querySelectorAll("TR");
+  if (TRs.length > 5) {
+    return [...TRs[0].querySelectorAll("TD")]
+  }
+}).filter(Boolean).flat(Infinity);
+var sortAsc = Array(tableHeaders.length).fill(1);
 for (j = 0; j < tableHeaders.length; ++j) {
-  tableHeaders.item(j).onclick = function() {
+  tableHeaders[j].onclick = function() {
 
     var tableObj = findParentNode('TABLE',this);
     var index = [].indexOf.call(this.parentNode.children, this);


### PR DESCRIPTION
### Support tables without headers
Fix #8  , and indirectly #16 .

If no `TH` exists in a table, search for `TR` instead, and assume that the first rows `TD` nodes are the headers.

Since many old webpages still use tables for design and we want to avoid adding onClick for things that are not data tables, I added an arbitrary restriction for tables without `TH` where we only sort them if they have more than 5 rows.


### Add table cells to the tbody instead of the table.
Fix #12 
Most tables include a `tbody`, but currently we sort and readd the rows to the table, instead of the body, which on many webpages breaks the design. Now we should correctly add cells to the tbody if it exists.



